### PR TITLE
Two additional fixes

### DIFF
--- a/scripts/sendGraph.py
+++ b/scripts/sendGraph.py
@@ -155,8 +155,11 @@ def get_peers(con, path):
             break
 
     if 'result' not in res or res['result'] != 'peers':
-        print('get_peers: failed too many times, skipping.')
-        print(res)
+        if 'result' in res and res['result'] == 'timeout':
+            print('get_peers: timed out on final try, skipping.')
+        else:
+            print('get_peers: failed too many times, skipping. Last response: {:s}'
+                  .format(str(res)))
         return peers
 
     for peer in res['peers']:

--- a/scripts/sendGraph.py
+++ b/scripts/sendGraph.py
@@ -208,7 +208,7 @@ def send_graph(nodes, edges):
     payload = {'data': json_graph, 'mail': your_mail, 'version': 2}
     r = requests.post(url, data=payload)
 
-    if r.content == 'OK':
+    if r.text == 'OK':
         print('Done!')
     else:
         print('Error: {:s}'.format(r.text))


### PR DESCRIPTION
Seems I missed another use of `r.content`, and to commit the clarification on the message printed when skipping a node. Sorry 'bout that.
