### PR TITLE
Skip not_found nodes, don't prefix error with "Error:"

### DIFF
--- a/scripts/sendGraph.py
+++ b/scripts/sendGraph.py
@@ -153,7 +153,12 @@ def get_peers(con, path, nearbyPath=''):
             res = con.RouterModule_getPeers(path)
 
 
-        if res['error'] != 'none':
+        if res['error'] == 'not_found':
+            print('get_peers: node with path {:s} not found, skipping.'
+                  .format(formatted_path))
+            return []
+
+        elif res['error'] != 'none':
             print('get_peers: failed with error `{:s}` on {:s}, trying again. {:d} tries remaining.'
                   .format(res['error'], formatted_path, retry-i))
         elif res['result'] == 'timeout':

--- a/scripts/sendGraph.py
+++ b/scripts/sendGraph.py
@@ -169,7 +169,7 @@ def get_peers(con, path, nearbyPath=''):
 
         i += 1
 
-    print('get_peers: timed out on final try, skipping {:s}'
+    print('get_peers: failed on final try, skipping {:s}'
           .format(formatted_path))
     return []
 
@@ -256,7 +256,7 @@ def send_graph(nodes, edges):
     if r.text == 'OK':
         print('Done!')
     else:
-        print('Error: {:s}'.format(r.text))
+        print('{:s}'.format(r.text))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
1) Don't retry issuing `getPeers` when the previous response wan "not_found"
2) The error message from fc00 is already prefixed with 'Error:' so no need to duplicate it.
