### PR TITLE
Updates for v0.3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,8 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ 
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,21 @@
-# fc00.org
+# Yggdrasil map
 
-Source code for http://www.fc00.org (http://h.fc00.org on Hyperboria).
+Forked from the code for http://www.fc00.org (http://h.fc00.org on Hyperboria).
 
 ## Sending your view of the network
 
-In order to display accurate map of Hyperboria fc00 need your help. If you run CJDNS node, please send your network view using sendGraph.py script.
-
-```bash
-# Install requests and cjdns for Python 3
-pip3 install cjdns requests
-# Get the script
-wget https://raw.githubusercontent.com/zielmicha/fc00.org/master/scripts/sendGraph.py
-# Edit configuration
-nano sendGraph.py
-chmod +x sendGraph.py
-
-# Run this every 20-100 minutes
-./sendGraph.py
-# For example, add it to crontab
-(crontab -l; echo "@hourly /root/sendGraph.py") | crontab -
-```
+This code reads a map of known nodes from `y.yakamo.org:3000/current` (reachable over yggdrasil). In order to display an accurate map of the network, we need your help. If you run a yggdrasil node, plase send your network view using the [send-view.py](https://github.com/yakamok/Niflheim-api/blob/master/send-view.py) script.
 
 ## Web server
 ```bash
-git clone git@github.com:zielmicha/fc00.org.git
-git clone git@github.com:zielmicha/nodedb.git web/nodedb
-sudo apt-get install python-flask python-flup python-mysqldb python-pygraphviz
+git clone https://github.com/Arceliar/yggdrasil-map.git
+sudo apt-get install python-flask python-flup python-mysqldb python-pygraphviz python-networkx
 
-cd fc00.org/web
+cd yggdrasil-map/web
+cp web_config.example.cfg web_config.cfg
 python web.py
 ```
+
+You would need to edit web.py to adjust the address/port the server listens on, and may want to edit the web_config.cfg file. Note that most of the options in web_config.cfg are unused after forking from the fc00.org code, so this is mostly just a workaround until we have time to clean up this code.
 
 Run `web/updateGraph.py` periodically to rerender nodes graph. You may want to customize reverse-proxy IP retrieval logic in web.py.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Forked from the code for http://www.fc00.org (http://h.fc00.org on Hyperboria).
 
 ## Sending your view of the network
 
-This code reads a map of known nodes from `y.yakamo.org:3000/current` (reachable over yggdrasil). In order to display an accurate map of the network, we need your help. If you run a yggdrasil node, plase send your network view using the [send-view.py](https://github.com/yakamok/Niflheim-api/blob/master/send-view.py) script.
+This code reads a map of known nodes from `y.yakamo.org:3000/current` (reachable over yggdrasil). You may alternatively generate your own view of the network by running [a crawler script](scripts/crawl-dht.py), but this may take some time (figuring out how to run it and use the results is left as an exercise to the user).
 
 ## Web server
 ```bash

--- a/scripts/crawl-dht.py
+++ b/scripts/crawl-dht.py
@@ -1,0 +1,75 @@
+import json
+import socket
+import sys
+import time
+
+#gives the option to get data from an external server instead and send that
+#if no options given it will default to localhost instead
+if len(sys.argv) == 3:
+  host_port = (sys.argv[1], int(sys.argv[2]))
+else:
+  host_port = ('localhost', 9001)
+
+def getDHTPingRequest(key, coords, target=None):
+  if target:
+    return '{{"keepalive":true, "request":"dhtPing", "box_pub_key":"{}", "coords":"{}", "target":"{}"}}'.format(key, coords, target)
+  else:
+    return '{{"keepalive":true, "request":"dhtPing", "box_pub_key":"{}", "coords":"{}"}}'.format(key, coords)
+
+def doRequest(req):
+  try:
+    ygg = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    ygg.connect(host_port)
+    ygg.send(req)
+    data = json.loads(ygg.recv(1024*15))
+    return data
+  except:
+    return None
+
+visited = dict() # Add nodes after a successful lookup response
+rumored = dict() # Add rumors about nodes to ping
+timedout = dict()
+def handleResponse(address, info, data):
+  global visited
+  global rumored
+  global timedout
+  timedout[str(address)] = {'box_pub_key':str(info['box_pub_key']), 'coords':str(info['coords'])}
+  if not data: return
+  if 'response' not in data: return
+  if 'nodes' not in data['response']: return
+  for addr,rumor in data['response']['nodes'].iteritems():
+    if addr in visited: continue
+    rumored[addr] = rumor
+  if address not in visited:
+    # TODO? remove this, it's debug output that happens to be in the same format as yakamo's "current" json file
+    now = time.time()
+    visited[str(address)] = {'box_pub_key':str(info['box_pub_key']), 'coords':str(info['coords']), 'time':now}
+    if address in timedout: del timedout[address]
+    if len(visited) > 1: sys.stdout.write(",\n")
+    sys.stdout.write('"{}": ["{}", {}]'.format(address, info['coords'], int(now)))
+    sys.stdout.flush()
+# End handleResponse
+
+# Get self info
+selfInfo = doRequest('{"keepalive":true, "request":"getSelf"}')
+
+# Initialize dicts of visited/rumored nodes
+for k,v in selfInfo['response']['self'].iteritems(): rumored[k] = v
+
+# Loop over rumored nodes and ping them, adding to visited if they respond
+print '{"yggnodes": {'
+while len(rumored) > 0:
+  for k,v in rumored.iteritems():
+    handleResponse(k, v, doRequest(getDHTPingRequest(v['box_pub_key'], v['coords'])))
+    # These next two are imperfect workarounds to deal with old kad nodes
+    handleResponse(k, v, doRequest(getDHTPingRequest(v['box_pub_key'], v['coords'], '0'*128)))
+    handleResponse(k, v, doRequest(getDHTPingRequest(v['box_pub_key'], v['coords'], 'f'*128)))
+    break
+  del rumored[k]
+print '\n}}'
+#End
+
+# TODO do something with the results
+
+#print visited
+#print timedout

--- a/web/graphPlotter.py
+++ b/web/graphPlotter.py
@@ -8,10 +8,10 @@ def position_nodes(nodes, edges):
     G = pgv.AGraph(strict=True, directed=False, size='10!')
 
     for n in nodes.values():
-        G.add_node(n.coords, label=n.ip, version=n.version)
+        G.add_node(n.ip, label=n.label, coords=n.coords)
 
     for e in edges:
-        G.add_edge(e.a.coords, e.b.coords, len=1.0)
+        G.add_edge(e.a.ip, e.b.ip, len=1.0)
 
     G.layout(prog='neato', args='-Gepsilon=0.0001 -Gmaxiter=100000')
 
@@ -66,7 +66,7 @@ def get_graph_json(G):
             'id': n.name,
             'label': name if name else n.attr['label'],
             'name': name,
-            'version': n.attr['version'],
+            'coords': n.attr['coords'],
             'x': float(pos[0]),
             'y': float(pos[1]),
             'color': _gradient_color(neighbor_ratio, [(100, 100, 100), (0, 0, 0)]),

--- a/web/graphPlotter.py
+++ b/web/graphPlotter.py
@@ -8,10 +8,10 @@ def position_nodes(nodes, edges):
     G = pgv.AGraph(strict=True, directed=False, size='10!')
 
     for n in nodes.values():
-        G.add_node(n.ip, label=n.label, version=n.version)
+        G.add_node(n.coords, label=n.ip, version=n.version)
 
     for e in edges:
-        G.add_edge(e.a.ip, e.b.ip, len=1.0)
+        G.add_edge(e.a.coords, e.b.coords, len=1.0)
 
     G.layout(prog='neato', args='-Gepsilon=0.0001 -Gmaxiter=100000')
 
@@ -53,7 +53,7 @@ def get_graph_json(G):
     }
 
     centralities = compute_betweenness(G)
-    db = load_db()
+    #db = load_db()
 
     for n in G.iternodes():
         neighbor_ratio = len(G.neighbors(n)) / float(max_neighbors)
@@ -61,7 +61,7 @@ def get_graph_json(G):
         centrality = centralities.get(n.name, 0)
         pcentrality = (centrality + 0.0001) * 500
         size = (pcentrality ** 0.3 / 500) * 1000 + 1
-        name = db.get(n.name)
+        name = None#db.get(n.name)
 
         out_data['nodes'].append({
             'id': n.name,

--- a/web/graphPlotter.py
+++ b/web/graphPlotter.py
@@ -59,8 +59,7 @@ def get_graph_json(G):
         neighbor_ratio = len(G.neighbors(n)) / float(max_neighbors)
         pos = n.attr['pos'].split(',', 1)
         centrality = centralities.get(n.name, 0)
-        pcentrality = (centrality + 0.0001) * 500
-        size = (pcentrality ** 0.3 / 500) * 1000 + 1
+        size = 5*(1 + 1*centrality)
         name = None#db.get(n.name)
 
         out_data['nodes'].append({

--- a/web/static/network.js
+++ b/web/static/network.js
@@ -174,7 +174,7 @@ function showNodeInfo(node) {
         '<h2>' + node.label + '</h2>' +
         '<span class="tt">' + node.id + '</span><br>' +
         '<br>' +
-        '<strong>Version:</strong> ' + node.version + '<br>' +
+        '<strong>Coords:</strong> ' + node.coords + '<br>' +
         '<strong>Peers:</strong> ' + node.peers.length + '<br>' +
         '<strong>Centrality:</strong> ' + node.centrality + '<br>' +
         '<table>' +

--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -8,7 +8,7 @@
 			<br>
 
 			<h3>Network map</h3>
-			<p>The network page has a map of Yggdrasil's spanning tree as it is now. The map is not complete since it is hard/impossible to get a full picture of the network, and it only includes the minimum subset of links needed to construct the spanning tree. The known nodes and tree coordinates are taken from <a href="http://y.yakamo.org:3000/">Yakamo's API</a>. You can submit your node's view of the network by periodically running <a href="https://github.com/yakamok/Niflheim-api/blob/master/send-view.py">send-view.py</a>.</p>
+			<p>The network page has a map of Yggdrasil's spanning tree as it is now. The map is not complete since it is hard/impossible to get a full picture of the network, and it only includes the minimum subset of links needed to construct the spanning tree. The known nodes and tree coordinates are taken from <a href="http://y.yakamo.org:3000/">Yakamo's API</a>.</p>
 			<!--
 			<h3>Node names</h3>
 			<p>For now, node names are assigned manually. You can submit Pull Request to <a href="https://github.com/zielmicha/nodedb">nodedb</a> if you want to have your node named. 

--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -8,7 +8,7 @@
 			<br>
 
 			<h3>Network map</h3>
-			<p>The network page has a map of Yggdrasil's spanning tree as it is now. The map is not complete since it is hard/impossible to get a full picture of the network, and it only includes the minimum subset of links needed to construct the spanning tree.</p>
+			<p>The network page has a map of Yggdrasil's spanning tree as it is now. The map is not complete since it is hard/impossible to get a full picture of the network, and it only includes the minimum subset of links needed to construct the spanning tree. The known nodes and tree coordinates are taken from <a href="http://y.yakamo.org:3000/">Yakamo's API</a>. You can submit your node's view of the network by periodically running <a href="https://github.com/yakamok/Niflheim-api/blob/master/send-view.py">send-view.py</a>.</p>
 			<!--
 			<h3>Node names</h3>
 			<p>For now, node names are assigned manually. You can submit Pull Request to <a href="https://github.com/zielmicha/nodedb">nodedb</a> if you want to have your node named. 

--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -15,7 +15,7 @@
 			In future this will be replaced by some reverse DNS system.
       -->
 			<h3>Contact</h3>
-			<p>This project was foked from <em>zielmicha</em>'s fork of <em>Randati</em>'s fc00. 
+			<p>This project was forked from <em>zielmicha</em>'s fork of <em>Randati</em>'s fc00. 
 	The yggdrasil developers can be contacted over matrix or IRC, for more info see: <a href="https://yggdrasil-network.github.io/">yggdrasil-network.github.io</a>.</p>
 		</div>
 	</div>

--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -3,20 +3,20 @@
 {% block content %}
 	<div id="content-wrapper">
 		<div id="content">
-			<h2>About fc00</h2>
-            <p>fc00 is a project that aims to demystify what <a href="http://hyperboria.net/">Hyperboria</a> network is like. Currently the only thing we have here is a map of the network. The full source code is at <a href="https://github.com/zielmicha/fc00.org">GitHub</a>.</p>
+			<h2>About</h2>
+            <p>This is a project that aims to demystify what the <a href="https://yggdrasil-network.github.io/">Yggdrasil</a> network is like. Currently the only thing we have here is a map of the spanning tree subset of the network. The full source code is at <a href="https://github.com/Arceliar/yggdrasil-map">GitHub</a>.</p>
 			<br>
 
 			<h3>Network map</h3>
-			<p>The network page has a map of Hyperboria as it is now. The map is not complete since it is hard/impossible to get a full picture of the network. A rough estimate is that at least half of the nodes are pictured here, probably more. The nodes and links that are shown on the page are very likely to exist but this should not be taken as a guarantee.</p>
-			
+			<p>The network page has a map of Yggdrasil's spanning tree as it is now. The map is not complete since it is hard/impossible to get a full picture of the network, and it only includes the minimum subset of links needed to construct the spanning tree.</p>
+			<!--
 			<h3>Node names</h3>
 			<p>For now, node names are assigned manually. You can submit Pull Request to <a href="https://github.com/zielmicha/nodedb">nodedb</a> if you want to have your node named. 
 			In future this will be replaced by some reverse DNS system.
-
+      -->
 			<h3>Contact</h3>
-			<p>fc00 was orginally created by <em>Randati</em>. fc00 is currently run by <em>zielmicha</em>. 
-	If you have something to say or you would like to help, contact him via michal@zielinscy.org.pl.</p>
+			<p>This project was foked from <em>zielmicha</em>'s fork of <em>Randati</em>'s fc00. 
+	The yggdrasil developers can be contacted over matrix or IRC, for more info see: <a href="https://yggdrasil-network.github.io/">yggdrasil-network.github.io</a>.</p>
 		</div>
 	</div>
 {% endblock %}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -2,19 +2,19 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
-		<title>fc00::/8 – Mapping Hyperboria</title>
+		<title>0200::/7 – Mapping The Yggdrasil Network</title>
 		<script src="static/jquery-2.0.3.min.js"></script>
 		<script src="static/jquery.autocomplete.min.js"></script>
 		<link href='static/style.css' rel='stylesheet' type='text/css'>
 	</head>
 	<body>
 		<div id="header">
-			<h1>fc00<span class="grey">::/8</span></h1>
+			<h1>0200<span class="grey">::/7</span></h1>
 
 			<ul>
 				<li><a href="/" {% if page == 'network' %} class="selected" {% endif %}>Network</a></li>
 				<li><a href="/about"{% if page == 'about' %} class="selected" {% endif %}>About</a></li>
-				<li><a href="https://github.com/zielmicha/fc00.org">Source</a></li>
+				<li><a href="https://github.com/Arceliar/yggdrasil-map">Source</a></li>
 				<li><tt>{% if ip is not none %}{{ ip }}{% endif %}</tt></li>
 			</ul>
 		</div>

--- a/web/updateGraph.py
+++ b/web/updateGraph.py
@@ -4,7 +4,7 @@ from database import NodeDB
 import graphPlotter
 
 import urllib, json
-url = "http://y.yakamo.org:3000/current"
+url = "current" #alternatively "http://y.yakamo.org:3000/current"
 
 # nodes indexed by coords
 class NodeInfo:

--- a/web/updateGraph.py
+++ b/web/updateGraph.py
@@ -3,16 +3,64 @@ from flask import Config
 from database import NodeDB
 import graphPlotter
 
+import urllib, json
+url = "http://y.yakamo.org:3000/current"
+
+# nodes indexed by coords
+class NodeInfo:
+  def __init__(self, ip, coords):
+    self.ip = str(ip)
+    self.label = str(ip) # TODO readable labels
+    self.coords = str(coords)
+    self.version = "unknown"
+  def getCoordList(self):
+    return self.coords.strip("[]").split(" ")
+  def getParent(self):
+    p = self.getCoordList()
+    if len(p) > 0: p = p[:-1]
+    return "[" + " ".join(p).strip() + "]"
+  def getLink(self):
+    c = self.getCoordList()
+    return int(self.getCoordList()[-1].strip() or "0")
+
+class LinkInfo:
+  def __init__(self, a, b):
+    self.a = a # NodeInfo
+    self.b = b # NodeInfo
 
 def generate_graph(time_limit=60*60*3):
-    nodes, edges = load_graph_from_db(time_limit)
+    response = urllib.urlopen(url)
+    data = json.loads(response.read())["yggnodes"]
+
+    toAdd = []
+    for ip in data:
+      info = NodeInfo(ip, data[ip][0])
+      toAdd.append(info)
+
+    nodes = dict()
+    def addAncestors(info):
+      parent = NodeInfo("?", info.getParent())
+      nodes[parent.coords] = parent
+      if parent.coords != parent.getParent(): addAncestors(parent)
+
+    for info in toAdd: addAncestors(info)
+    for info in toAdd: nodes[info.coords] = info
+
+    sortedNodes = sorted(nodes.values(), key=(lambda x: x.getLink()))
+    #for node in sortedNodes: print node.ip, node.coords, node.getParent(), node.getLink()
+
+    edges = []
+    for node in sortedNodes:
+      if node.coords == node.getParent: continue
+      edges.append(LinkInfo(node, nodes[node.getParent()]))
+
     print '%d nodes, %d edges' % (len(nodes), len(edges))
 
     graph = graphPlotter.position_nodes(nodes, edges)
-    json = graphPlotter.get_graph_json(graph)
+    js = graphPlotter.get_graph_json(graph)
 
     with open('static/graph.json', 'w') as f:
-        f.write(json)
+        f.write(js)
 
 
 def load_graph_from_db(time_limit):

--- a/web/updateGraph.py
+++ b/web/updateGraph.py
@@ -40,6 +40,7 @@ def generate_graph(time_limit=60*60*3):
     nodes = dict()
     def addAncestors(info):
       parent = NodeInfo("?", info.getParent())
+      parent.label = "{} {}".format(parent.ip, parent.coords)
       nodes[parent.coords] = parent
       if parent.coords != parent.getParent(): addAncestors(parent)
 


### PR DESCRIPTION
Adds a crawler script that can use the new `dhtPing` admin call to map the network (yakamo now uses a version of this).

Updated some documentation to e.g. remove references to the old send-view.py script.

Changed the graph a little so obvious things, like clicking an IP address in a node's peer list, work as expected.