### PR TITLE
LibreJS compliance

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -6,6 +6,11 @@
 		<script src="static/jquery-2.0.3.min.js"></script>
 		<script src="static/jquery.autocomplete.min.js"></script>
 		<link href='static/style.css' rel='stylesheet' type='text/css'>
+		
+		<!-- link to JS licenses for LibreJS -->
+		<div style="display:none">
+			<a href="js-licenses" data-jslicense="1">JavaScript license information</a>
+		</div>
 	</head>
 	<body>
 		<div id="header">

--- a/web/templates/js-licenses.html
+++ b/web/templates/js-licenses.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+	<div id="content-wrapper">
+		<div id="content">
+			<table id="jslicense-labels1" border="1">
+				<tr>
+					<td><a href="static/jquery-2.0.3.min.js">static/jquery-2.0.3.min.js</a></td>
+					<td><a href="magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt">Expat</a></td>
+					<td><a href="https://raw.githubusercontent.com/jquery/codeorigin.jquery.com/master/cdn/jquery-2.0.3.js">jquery-2.0.3.js</a></td>
+				<tr>
+				
+				<tr>
+					<td><a href="static/jquery.autocomplete.min.js">static/jquery.autocomplete.min.js</a></td>
+					<td><a href="magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt">Expat</a></td>
+					<td><a href="https://raw.githubusercontent.com/devbridge/jQuery-Autocomplete/4924da0b519e8408fad10a746d2fe9ccfb859f80/dist/jquery.autocomplete.js">jquery.autocomplete.js</a></td>
+				<tr>
+				
+				<tr>
+					<td><a href="static/network.js">static/network.js</a></td>
+					<td><a href="magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt">GNU-GPL-3.0-or-later</a></td>
+					<td><a href="static/network.js">static/network.js</a></td>
+				<tr>
+			</table>
+		</div>
+	</div>
+{% endblock %}

--- a/web/web.py
+++ b/web/web.py
@@ -41,5 +41,9 @@ def page_sendGraph():
     else:
         return 'Error: %s' % ret
 
+@app.route('/js-licenses')
+def page_js_licenses():
+    return render_template('js-licenses.html', page='js-licenses')
+
 if __name__ == '__main__':
     app.run(host='localhost', port=3000)


### PR DESCRIPTION
PR to close #31 

This PR creates a page titled js-licenses, which lists the licenses for the three JS files, as well as pointing to non-minified source code. This page is invisibly linked from base.html, thus all pages on the site, allowing LibreJS to find the licenses for the JS on the site from any page.

The network.js file did not list a license, so I assumed it was GPLv3 along with the project as a whole.