### PR TITLE
Added <a> tag around the IP displayed in the sidebar for easier access

### DIFF
--- a/web/static/network.js
+++ b/web/static/network.js
@@ -172,7 +172,7 @@ function showNodeInfo(node) {
 
     var html =
         '<h2>' + node.label + '</h2>' +
-        '<span class="tt">' + node.id + '</span><br>' +
+        '<span class="tt"><a href="http://[' + node.id + ']">'+node.id+'</a></span><br>' +
         '<br>' +
         '<strong>Version:</strong> ' + node.version + '<br>' +
         '<strong>Peers:</strong> ' + node.peers.length + '<br>' +


### PR DESCRIPTION
Some nodes have HTTP servers running on them; I find it easier to just click on the address displayed in the sidebar node information area instead of copying and pasting it, making sure to add [].